### PR TITLE
Password validation rules

### DIFF
--- a/src/MeAgendaAi.Domain/Interfaces/Services/IUserService.cs
+++ b/src/MeAgendaAi.Domain/Interfaces/Services/IUserService.cs
@@ -5,5 +5,7 @@ namespace MeAgendaAi.Domains.Interfaces.Services
     public interface IUserService : IService<User>
     {
         Task<bool> HasUser(string email);
+        bool SamePassword(string password, string confirmPassword);
+        bool NotSamePassword(string password, string confirmPassword);
     }
-} 
+}

--- a/src/MeAgendaAi.Domain/Validators/UserValidator.cs
+++ b/src/MeAgendaAi.Domain/Validators/UserValidator.cs
@@ -6,12 +6,16 @@ namespace MeAgendaAi.Domains.Validators
 {
     public class UserValidator<T> : AbstractValidator<T> where T : User
     {
+        const int LENGTH_PASSWORD_MINIMUM = 06;
+        const int LENGTH_PASSWORD_MAXIMUM = 32;
         public UserValidator()
         {
             RuleFor(prop => prop.Email)
                 .SetValidator(new EmailValidator());
             RuleFor(prop => prop.Password)
-                .NotEmpty().WithMessage("Password cannot be empty");
+                .NotEmpty().WithMessage("Password cannot be empty")
+                .MinimumLength(LENGTH_PASSWORD_MINIMUM).WithMessage($"Password must contain at least {LENGTH_PASSWORD_MINIMUM} characters")
+                .MaximumLength(LENGTH_PASSWORD_MAXIMUM).WithMessage($"Password must contain a maximum of {LENGTH_PASSWORD_MAXIMUM} characters");
         }
-    } 
+    }
 }

--- a/src/MeAgendaAi.Domain/ValueObjects/NameObject.cs
+++ b/src/MeAgendaAi.Domain/ValueObjects/NameObject.cs
@@ -5,7 +5,7 @@ namespace MeAgendaAi.Domains.ValueObjects
     public class NameObject : ValueObjects
     {
         public string Name { get; private set; }
-        public string? Surname { get; private set; }
+        public string Surname { get; private set; } = default!;
         public string FullName => $"{Name} {Surname}".Trim();
 
         public NameObject(string name)

--- a/src/MeAgendaAi.Services/CompanyService.cs
+++ b/src/MeAgendaAi.Services/CompanyService.cs
@@ -26,6 +26,12 @@ namespace MeAgendaAi.Services
                 return Guid.Empty;
             }
 
+            if (_userService.NotSamePassword(request.Password, request.ConfirmPassword))
+            {
+                _notificationContext.AddNotification("ConfirmPassword", "Senha de confirmação não é igual a senha");
+                return Guid.Empty;
+            }
+
             var company = new Company(request.Email, request.Password, request.Name, request.CNPJ, request.Description, request.LimitCancelHours);
             if (company.Invalid)
             {

--- a/src/MeAgendaAi.Services/PhysicalPersonService.cs
+++ b/src/MeAgendaAi.Services/PhysicalPersonService.cs
@@ -29,6 +29,12 @@ namespace MeAgendaAi.Services
                 return Guid.Empty;
             }
 
+            if (_userService.NotSamePassword(request.Password, request.ConfirmPassword))
+            {
+                _notificationContext.AddNotification("ConfirmPassword", "Senha de confirmação não é igual a senha");
+                return Guid.Empty;
+            }
+
             var physicalPerson = new PhysicalPerson(request.Email, request.Password, request.Name, request.Surname, request.CPF, request.RG);
             if (physicalPerson.Invalid)
             {

--- a/src/MeAgendaAi.Services/UserService.cs
+++ b/src/MeAgendaAi.Services/UserService.cs
@@ -14,6 +14,8 @@ namespace MeAgendaAi.Services.UserServices
         }
 
         public async Task<bool> HasUser(string email) => await _userRepository.GetByEmail(email) != null;
+        public bool SamePassword(string password, string confirmPassword) => password.Equals(confirmPassword);
+        public bool NotSamePassword(string password, string confirmPassword) => !SamePassword(password, confirmPassword);
     }
 
 }

--- a/test/MeAgendaAi.Common/Builder/BaseBuilder.cs
+++ b/test/MeAgendaAi.Common/Builder/BaseBuilder.cs
@@ -1,8 +1,6 @@
 ﻿using AutoBogus;
-using FluentValidation;
 using FluentValidation.Results;
 using MeAgendaAi.Domains.Entities.Base;
-using MeAgendaAi.Domains.Validators;
 using MeAgendaAi.Domains.ValueObjects;
 
 namespace MeAgendaAi.Common.Builder

--- a/test/MeAgendaAi.Common/Builder/Common/PasswordBuilder.cs
+++ b/test/MeAgendaAi.Common/Builder/Common/PasswordBuilder.cs
@@ -1,0 +1,16 @@
+﻿using AutoBogus;
+using Bogus;
+
+namespace MeAgendaAi.Common.Builder.Common
+{
+    public static class PasswordBuilder
+    {
+        const int LENGTH_PASSWORD_MINIMUM = 06;
+        const int LENGTH_PASSWORD_MAXIMUM = 32;
+        public static string Generate(int lengthMininum = LENGTH_PASSWORD_MINIMUM, int lengthMaximium = LENGTH_PASSWORD_MAXIMUM)
+        {
+            var faker = new Faker();
+            return faker.Internet.Password(length: faker.Random.Int(lengthMininum, lengthMaximium));
+        }
+    }
+}

--- a/test/MeAgendaAi.Common/Builder/PhysicalPersonBuilder.cs
+++ b/test/MeAgendaAi.Common/Builder/PhysicalPersonBuilder.cs
@@ -1,4 +1,5 @@
-﻿using MeAgendaAi.Common.Builder.ValuesObjects;
+﻿using MeAgendaAi.Common.Builder.Common;
+using MeAgendaAi.Common.Builder.ValuesObjects;
 using MeAgendaAi.Domains.Entities;
 using MeAgendaAi.Domains.RequestAndResponse;
 using MeAgendaAi.Domains.Validators;
@@ -11,8 +12,7 @@ namespace MeAgendaAi.Common.Builder
         public PhysicalPersonBuilder() : base()
         {
             RuleFor(x => x.Email, () => new EmailObjectBuilder().Generate());
-            RuleFor(x => x.Password, faker => faker.Internet.Password());
-
+            RuleFor(x => x.Password, PasswordBuilder.Generate());
             RuleFor(x => x.Name, () => new NameObjectBuilder().Generate());
             RuleFor(x => x.CPF, faker => faker.Random.Int(11).ToString());
             RuleFor(x => x.RG, faker => faker.Random.Int(9).ToString());

--- a/test/MeAgendaAi.Common/Builder/RequestAndResponse/AddCompanyRequestBuilder.cs
+++ b/test/MeAgendaAi.Common/Builder/RequestAndResponse/AddCompanyRequestBuilder.cs
@@ -63,5 +63,10 @@ namespace MeAgendaAi.Common.Builder.RequestAndResponse
             builder.WithEmail(email);
             return builder;
         }
+        public static AddCompanyRequestBuilder WithConfirmPassword(this AddCompanyRequestBuilder builder, string confirmPassword = "")
+        {
+            builder.RuleFor(prop => prop.ConfirmPassword, () => confirmPassword);
+            return builder;
+        }
     }
 }

--- a/test/MeAgendaAi.Common/Builder/RequestAndResponse/AddPhysicalPersonRequestBuilder.cs
+++ b/test/MeAgendaAi.Common/Builder/RequestAndResponse/AddPhysicalPersonRequestBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using AutoBogus;
 using Bogus;
+using MeAgendaAi.Common.Builder.Common;
 using MeAgendaAi.Domains.RequestAndResponse;
 
 namespace MeAgendaAi.Common.Builder.RequestAndResponse
@@ -8,15 +9,15 @@ namespace MeAgendaAi.Common.Builder.RequestAndResponse
     {
         public AddPhysicalPersonRequestBuilder()
         {
-            var password = new Faker().Internet.Password();
+            var password = PasswordBuilder.Generate();
             RuleFor(prop => prop.Name, faker => faker.Name.FirstName());
             RuleFor(prop => prop.Email, faker => faker.Internet.Email());
-            RuleFor(x => x.Password, () => password);
-            RuleFor(x => x.ConfirmPassword, () => password);
+            RuleFor(prop => prop.Password, () => password);
+            RuleFor(prop => prop.ConfirmPassword, () => password);
 
             RuleFor(prop => prop.Surname, faker => faker.Name.LastName());
-            RuleFor(x => x.CPF, faker => faker.Random.Int(11).ToString());
-            RuleFor(x => x.RG, faker => faker.Random.Int(9).ToString());
+            RuleFor(prop => prop.CPF, faker => faker.Random.Int(11).ToString());
+            RuleFor(prop => prop.RG, faker => faker.Random.Int(9).ToString());
         }
     }
 
@@ -53,7 +54,11 @@ namespace MeAgendaAi.Common.Builder.RequestAndResponse
         {
             builder.WithEmail(email);
             return builder;
-        }        
-        
+        }
+        public static AddPhysicalPersonRequestBuilder WithConfirmPassword(this AddPhysicalPersonRequestBuilder builder, string confirmPassword = "")
+        {
+            builder.RuleFor(prop => prop.ConfirmPassword, () => confirmPassword);
+            return builder;
+        }
     }
 }

--- a/test/MeAgendaAi.Unit/Domain/PhysicalPersonTest.cs
+++ b/test/MeAgendaAi.Unit/Domain/PhysicalPersonTest.cs
@@ -1,6 +1,7 @@
 ﻿using Bogus;
 using FluentAssertions;
-using MeAgendaAi.Common.Builder;
+using MeAgendaAi.Common.Builder.Common;
+using MeAgendaAi.Common.Builder.ValuesObjects;
 using MeAgendaAi.Domains.Entities;
 using NUnit.Framework;
 
@@ -8,19 +9,19 @@ namespace MeAgendaAi.Unit.Domain
 {
     public class PhysicalPersonTest
     {
-        private readonly Faker Faker;
+        private readonly Faker _faker;
 
-        public PhysicalPersonTest() => Faker = new Faker();
+        public PhysicalPersonTest() => _faker = new Faker();
 
         [Test]
         public void ShouldCreatedAnInstanceValidOfTypePhysicalPerson()
         {
-            var email = Faker.Internet.Email();
-            var password = Faker.Internet.Password();
-            var name = Faker.Name.FirstName();
-            var surname = Faker.Name.LastName();
-            var cpf = Faker.Random.Int(11).ToString();
-            var rg = Faker.Random.Int(9).ToString();
+            var email = _faker.Internet.Email();
+            var password = PasswordBuilder.Generate();
+            var name = _faker.Name.FirstName();
+            var surname = _faker.Name.LastName();
+            var cpf = _faker.Random.Int(11).ToString();
+            var rg = _faker.Random.Int(9).ToString();
 
             var physicalPerson = new PhysicalPerson(email, password, name, surname, cpf, rg);
 
@@ -31,16 +32,24 @@ namespace MeAgendaAi.Unit.Domain
         [Test]
         public void ShouldCreatedAnInstanceValidOfTypePhysicalPersonWithCorrectValues()
         {
-            var physicalPersonExpected = new PhysicalPersonBuilder().Generate();
+            var physicalPersonExpected = new
+            {
+                Email = new EmailObjectBuilder().Generate(),
+                Password = PasswordBuilder.Generate(),
+                Name = new NameObjectBuilder().Generate(),
+                CPF = _faker.Random.Int(11).ToString(),
+                RG = _faker.Random.Int(9).ToString(),
+            };
 
-            var physicalPerson = new PhysicalPerson(physicalPersonExpected.Email.Email, physicalPersonExpected.Password,
-                                                    physicalPersonExpected.Name.Name, physicalPersonExpected.Name.Surname,
-                                                    physicalPersonExpected.CPF, physicalPersonExpected.RG);
+            var physicalPerson = new PhysicalPerson(
+                physicalPersonExpected.Email.Email,
+                physicalPersonExpected.Password,
+                physicalPersonExpected.Name.Name,
+                physicalPersonExpected.Name.Surname,
+                physicalPersonExpected.CPF,
+                physicalPersonExpected.RG);
 
-            physicalPerson.Should().BeEquivalentTo(physicalPersonExpected,
-                options => options.Excluding(prop => prop.Id)
-                                  .Excluding(prop => prop.CreatedAt)
-                                  .Excluding(prop => prop.LastUpdatedAt));
+            physicalPerson.Should().BeEquivalentTo(physicalPersonExpected, options => options.ExcludingMissingMembers());
         }
     }
 }

--- a/test/MeAgendaAi.Unit/Domain/UserTest.cs
+++ b/test/MeAgendaAi.Unit/Domain/UserTest.cs
@@ -39,7 +39,7 @@ namespace MeAgendaAi.Unit.Domain
         [TestCase("", "E-mail cannot be empty")]
         [TestCase(null, "E-mail cannot be empty")]
         [TestCase("email", "Invalid e-mail")]
-        [TestCase("email@", "Invalid e-mail")]        
+        [TestCase("email@", "Invalid e-mail")]
         public void ShouldCreateAnInvalidInstanceOfUserWithInvalidEmail(string email, string errorMessage)
         {
             var password = Faker.Internet.Password();
@@ -65,5 +65,25 @@ namespace MeAgendaAi.Unit.Domain
             user.Valid.Should().BeFalse();
             user.Invalid.Should().BeTrue();
         }
+
+        [TestCase(0, "Password cannot be empty")]
+        [TestCase(2, "Password must contain at least 6 characters")]
+        [TestCase(5, "Password must contain at least 6 characters")]
+        [TestCase(33, "Password must contain a maximum of 32 characters")]
+        [TestCase(40, "Password must contain a maximum of 32 characters")]
+        public void ShouldCreateAnInvalidInstanceOfUserWithLengthInvalidPassword(int lengthPassword, string errorMessage)
+        {
+            var email = Faker.Internet.Email();
+            string charsAccepted = "abcdefghijklmnopqrstuvwxyz0123456789!@#$%*()/*-+";
+            var password = Faker.Random.String2(lengthPassword, charsAccepted);
+
+            var user = new User(email, password);
+
+            var errors = user.ValidationResult.Errors;
+            errors.Should().Contain(error => error.ErrorMessage == errorMessage);
+            user.Valid.Should().BeFalse();
+            user.Invalid.Should().BeTrue();
+        }
+
     }
 }

--- a/test/MeAgendaAi.Unit/Services/UserServiceTest.cs
+++ b/test/MeAgendaAi.Unit/Services/UserServiceTest.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using Bogus;
+using FluentAssertions;
 using MeAgendaAi.Common.Builder;
 using MeAgendaAi.Common.Builder.ValuesObjects;
 using MeAgendaAi.Domains.Interfaces.Repositories;
@@ -15,16 +16,16 @@ namespace MeAgendaAi.Unit.Services
     {
 
         private readonly Mock<IUserRepository> _mockUserRepository;
-        private readonly UserService userService;
+        private readonly UserService _userService;
 
         public UserServiceTest()
         {
             _mockUserRepository = new Mock<IUserRepository>();
-            userService = new UserService(_mockUserRepository.Object);
+            _userService = new UserService(_mockUserRepository.Object);
         }
 
         [Test]
-        public async Task ShouldCheckIfUserExistsAndReturnTrue()
+        public async Task HasUser_ShouldCheckIfUserExistsAndReturnTrue()
         {
             var physicalPerson = new PhysicalPersonBuilder().Generate();
             var email = physicalPerson.Email.Email;
@@ -32,25 +33,25 @@ namespace MeAgendaAi.Unit.Services
                 .Setup(method => method.GetByEmail(It.Is<string>(prop => prop == email)))
                 .ReturnsAsync(physicalPerson);
 
-            var response = await userService.HasUser(email);
+            var response = await _userService.HasUser(email);
 
             response.Should().BeTrue();
         }
 
         [Test]
-        public async Task ShouldCheckIfUserExistsAndReturnFalse()
+        public async Task HasUser_ShouldCheckIfUserExistsAndReturnFalse()
         {
             var email = new EmailObjectBuilder().Generate();
             _mockUserRepository
                 .Setup(method => method.GetByEmail(It.Is<string>(prop => prop == email.Email)));
 
-            var response = await userService.HasUser(email.Email);
+            var response = await _userService.HasUser(email.Email);
 
             response.Should().BeFalse();
         }
 
         [Test]
-        public async Task ShouldCheckIfUserExistsAndCallMethodGetByEmailOfUserRepositoryOnce()
+        public async Task HasUser_ShouldCheckIfUserExistsAndCallMethodGetByEmailOfUserRepositoryOnce()
         {
             var physicalPerson = new PhysicalPersonBuilder().Generate();
             var email = physicalPerson.Email.Email;
@@ -58,9 +59,66 @@ namespace MeAgendaAi.Unit.Services
                 .Setup(method => method.GetByEmail(It.Is<string>(prop => prop == email)))
                 .ReturnsAsync(physicalPerson);
 
-            var response = await userService.HasUser(email);
+            var response = await _userService.HasUser(email);
 
             _mockUserRepository.Verify(method => method.GetByEmail(It.Is<string>(prop => prop == email)), Times.Once());
+        }
+
+
+        [Test]
+        public void SamePassword_PasswordAndConfirmPasswordShouldTheSameAndReturnTrue()
+        {
+            const int LENGTH_MININUM_PASSWORD = 06;
+            const int LENGTH_MAXIMUM_PASSWORD = 32;
+            var faker = new Faker();
+            var password = faker.Internet.Password(faker.Random.Int(LENGTH_MININUM_PASSWORD, LENGTH_MAXIMUM_PASSWORD));
+            var confirmPassword = password;
+
+            var response = _userService.SamePassword(password, confirmPassword);
+
+            response.Should().BeTrue();
+        }
+
+        [Test]
+        public void SamePassword_PasswordAndConfirmPasswordShouldNotSameAndReturnFalse()
+        {
+            const int LENGTH_MININUM_PASSWORD = 06;
+            const int LENGTH_MAXIMUM_PASSWORD = 32;
+            var faker = new Faker();
+            var password = faker.Internet.Password(faker.Random.Int(LENGTH_MININUM_PASSWORD, LENGTH_MAXIMUM_PASSWORD));
+            var confirmPassword = faker.Internet.Password(faker.Random.Int(LENGTH_MININUM_PASSWORD, LENGTH_MAXIMUM_PASSWORD));
+
+            var response = _userService.SamePassword(password, confirmPassword);
+
+            response.Should().BeFalse();
+        }
+
+        [Test]
+        public void NotSamePassword_PasswordAndConfirmPasswordShouldNotSameAndReturnTrue()
+        {
+            const int LENGTH_MININUM_PASSWORD = 06;
+            const int LENGTH_MAXIMUM_PASSWORD = 32;
+            var faker = new Faker();
+            var password = faker.Internet.Password(faker.Random.Int(LENGTH_MININUM_PASSWORD, LENGTH_MAXIMUM_PASSWORD));
+            var confirmPassword = faker.Internet.Password(faker.Random.Int(LENGTH_MININUM_PASSWORD, LENGTH_MAXIMUM_PASSWORD));
+
+            var response = _userService.NotSamePassword(password, confirmPassword);
+
+            response.Should().BeTrue();
+        }
+
+        [Test]
+        public void NotSamePassword_PasswordAndConfirmPasswordShouldSameAndReturnFalse()
+        {
+            const int LENGTH_MININUM_PASSWORD = 06;
+            const int LENGTH_MAXIMUM_PASSWORD = 32;
+            var faker = new Faker();
+            var password = faker.Internet.Password(faker.Random.Int(LENGTH_MININUM_PASSWORD, LENGTH_MAXIMUM_PASSWORD));
+            var confirmPassword = password;
+
+            var response = _userService.NotSamePassword(password, confirmPassword);
+
+            response.Should().BeFalse();
         }
     }
 }


### PR DESCRIPTION
- Modifying password validation rule
- Adjusting MaximumLength error message from UserValidator
- PhysicalPersonTest test refactoring
- Implemented SamePassword and NotSamePassword methods.
- Using PasswordBuilder.cs
- SamePassword and NotSamePassword implementation
- Implementation of confirmPassword rule [No tests]
- Implemented test for verification of already registered Email and password and confirmation of different password
- Integration test
    - Test for return of not equal password notification
    - Test to return notification to user already registered
- Unit test
    - Test for adding notification when password is different from password confirmation.
    - Test not to run AddAsync when password and password confirmation different
- Modifying password validation rule
- Adjusting MaximumLength error message from UserValidator
- PhysicalPersonTest test refactoring
- Implemented SamePassword and NotSamePassword methods.
- Using PasswordBuilder.cs
- SamePassword and NotSamePassword implementation
- Implementation of confirmPassword rule [No tests]
- Implemented test for verification of already registered Email and password and confirmation of different password
- Integration test
    - Test for return of not equal password notification
    - Test to return notification to user already registered
- Unit test
    - Test for adding notification when password is different from password confirmation.
    - Test not to run AddAsync when password and password confirmation different